### PR TITLE
Personalize profile page with name, publications, and research projects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,14 +1,12 @@
-title: izone
-author: wizone
-email: your-email@domain.com
-description: > # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+title: Matthew Hwyjoon Jeon | AI Research & Development
+author: Matthew Hwyjoon Jeon
+email: your-email@example.com
+description: >
+  전휘준(Matthew Hwyjoon Jeon)의 GitHub Pages입니다. AI 연구, 논문, 프로젝트를 정리합니다.
 
 # social links
-twitter_username: your-twitter-handle # DO NOT include the @ character, or else the build will fail!
-github_username:  your-github-handle # DO NOT include the @ character, or else the build will fail!
+twitter_username: your-twitter-handle
+github_username: matthewjeon97
 
-show_excerpts: true # set to false to remove excerpts on the homepage
+show_excerpts: false
 theme: minima

--- a/index.md
+++ b/index.md
@@ -1,5 +1,137 @@
 ---
-title: "Welcome to my site"
+title: "About Me"
 ---
 
-I'm glad you are here. I plan to talk about ...
+<style>
+  .hero {
+    background: linear-gradient(135deg, #0a0f1f 0%, #0f1d3a 45%, #122b4f 100%);
+    border: 1px solid #2d4c7a;
+    border-radius: 14px;
+    padding: 2rem;
+    color: #e7f1ff;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+    position: relative;
+    overflow: hidden;
+    margin-bottom: 1.5rem;
+  }
+
+  .hero::before {
+    content: "010101 110010 101010 010111";
+    position: absolute;
+    top: 8px;
+    right: 14px;
+    font-size: 0.7rem;
+    color: rgba(123, 185, 255, 0.35);
+    letter-spacing: 2px;
+  }
+
+  .hero h1 {
+    margin-top: 0;
+    margin-bottom: 0.4rem;
+    color: #9bd1ff;
+  }
+
+  .hero p {
+    margin-bottom: 0;
+    color: #d8e9ff;
+  }
+
+  .section-card {
+    border: 1px solid #d8e8ff;
+    border-left: 4px solid #4f8fff;
+    border-radius: 10px;
+    padding: 1rem 1.2rem;
+    margin: 1rem 0;
+    background: #f8fbff;
+  }
+
+  .tag {
+    display: inline-block;
+    background: #e6f0ff;
+    border: 1px solid #b7d2ff;
+    color: #2457a6;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    padding: 0.15rem 0.6rem;
+    margin-right: 0.3rem;
+    margin-top: 0.3rem;
+  }
+
+  .paper-list li,
+  .project-list li {
+    margin-bottom: 1rem;
+  }
+
+  .meta {
+    color: #425466;
+    font-size: 0.95rem;
+  }
+</style>
+
+<div class="hero">
+  <h1>안녕하세요, 전휘준(Matthew Hwyjoon Jeon)입니다 👋</h1>
+  <p>
+    AI와 생성형 모델을 중심으로 연구와 개발을 연결하는 엔지니어입니다.<br />
+    <strong>Text-to-Image, Diffusion Model, LLM 응용</strong> 분야에 관심이 있습니다.
+  </p>
+</div>
+
+## 🚀 Profile
+
+<div class="section-card">
+  <ul>
+    <li><strong>이름</strong>: 전휘준 (Matthew Hwyjoon Jeon)</li>
+    <li><strong>관심 분야</strong>: Diffusion Model, Text-to-Image, LLM Application</li>
+    <li><strong>GitHub</strong>: <a href="https://github.com/matthewjeon97">github.com/matthewjeon97</a></li>
+  </ul>
+</div>
+
+<span class="tag">#DiffusionModel</span>
+<span class="tag">#TextToImage</span>
+<span class="tag">#LLM</span>
+<span class="tag">#AIResearch</span>
+
+## 📄 Publications
+
+<div class="section-card">
+  <ul class="paper-list">
+    <li>
+      <strong>CartoonizeDiff: diffusion-based photo cartoonization scheme</strong><br />
+      <span class="meta">Conference · Authors: H. Jeon et al. (First author: H. Jeon)</span>
+    </li>
+    <li>
+      <strong>A photo cartoonization method based on text-to-image diffusion model</strong><br />
+      <span class="meta">Journal · Authors: H. Jeon et al. (First author: H. Jeon)</span>
+    </li>
+  </ul>
+</div>
+
+## 🧪 Research Projects
+
+<div class="section-card">
+  <ul class="project-list">
+    <li>
+      <strong>2023.06 – 2025.02</strong><br />
+      한국연구재단 (National Research Foundation of Korea)<br />
+      객체 정체성을 유지하는 이미지 생성을 위한 묘사 텍스트 세분화 및 텍스트-이미지 생성 모델 연구<br />
+      <span class="meta">(A study on description text refinement and text-to-image generation model for image generation maintaining object identity)</span>
+    </li>
+    <li>
+      <strong>2023.03 – 2023.08</strong><br />
+      (주)로이드케이<br />
+      자연어 기반 검색 경험 향상<br />
+      <span class="meta">(Enhancement of Natural Language-Based Search Experience)</span>
+    </li>
+    <li>
+      <strong>2024.02 – 2024.08</strong><br />
+      LLM 솔루션 활용 및 환각현상 방지 연구개발<br />
+      <span class="meta">(Research and Development of LLM Solution Utilization and Hallucination Prevention)</span>
+    </li>
+    <li>
+      <strong>2023.03 – 2025.02</strong><br />
+      한국연구재단 (National Research Foundation of Korea)<br />
+      순서학습연구실: 비교적 데이터 분석 및 평가를 위한 인공지능 연구<br />
+      <span class="meta">(Order Learning Lab: Artificial Intelligence Research for Comparative Data Analysis and Evaluation)</span>
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
### Motivation
- Replace the repository's placeholder homepage with the user's real profile information and research record so the site reflects accurate personal and scholarly details.
- Surface the two provided paper titles and the four research projects prominently on the homepage for visitors and collaborators.
- Ensure site-level metadata (site title/author/GitHub handle) matches the personalized profile for correct rendering and attribution.

### Description
- Updated `index.md` to replace the placeholder hero, profile metadata, and sample content with the user's Korean/English name (전휘준 / Matthew Hwyjoon Jeon), research interests, two publication entries, and four research project records.
- Updated `_config.yml` to set `title`, `author`, `description`, `github_username`, and `show_excerpts` to values matching the personalized profile.
- Publications are shown as the provided titles and use `H. Jeon et al.` (first author: H. Jeon) as a placeholder author line because co-author metadata could not be retrieved in this environment.
- Preserved and adjusted existing styling in `index.md` so the new content displays consistently with the site's visual design.

### Testing
- Ran `bundle exec jekyll build` to validate the site build pipeline, which failed because this repository has no `Gemfile` / Bundler setup (build could not run).
- Attempted automated CrossRef metadata lookup to resolve co-authors and DOIs, which failed due to network/proxy restrictions returning a 403 error.
- Attempted Playwright-driven screenshot capture of the local site, which failed due to a Chromium process crash (SIGSEGV) in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bee0eddcc8321b10f3cdf3a9f0828)